### PR TITLE
Add help command with table design

### DIFF
--- a/app/handlers/execute_command.py
+++ b/app/handlers/execute_command.py
@@ -2,7 +2,7 @@ from typing import Callable
 from functools import partial
 
 from app.decorators import colored_output, input_error
-from app.messages import error_unexpected_arguments, hello_message
+from app.messages import error_unexpected_arguments, hello_message, help_message
 from app.models import AddressBook, NotesBook
 
 from .add_address import add_address
@@ -56,6 +56,7 @@ def execute_command(
 
     commands: dict[str, tuple[Callable[..., str], str]] = {
         "hello": (hello_message, "none"),
+        "help": (help_message, "none"),
         "add": (add_contact, "args_book"),
         "change": (change_contact, "args_book"),
         "phone": (show_phone, "args_book"),

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ def main() -> None:
     - add-birthday <name> <date>: Add birthday (DD.MM.YYYY)
     - show-birthday <name>: Show birthday for a contact
     - birthdays [days]: Show upcoming birthdays (default: next 7 days)
+    - help: Show all available commands and usage
     - close/exit: Terminate the program
 
     The bot runs in an infinite loop until the user enters "close" or "exit".

--- a/app/message_texts.py
+++ b/app/message_texts.py
@@ -63,8 +63,37 @@ UNKNOWN_COMMAND = (
     "add-email, add-address, add-note, show-email, show-address, show-notes, search, "
     "search-name, search-phone, search-email, search-address, search-birthday, "
     "add-birthday, show-birthday, birthdays, "
-    "delete-note, edit-note, search-notes, close, exit"
+    "delete-note, edit-note, search-notes, help, close, exit"
 )
+
+HELP_COMMANDS: list[tuple[str, str]] = [
+    ("hello", "Show greeting"),
+    ("add <name> <phone>", "Add contact or add phone to existing"),
+    ("change <name> <old_phone> <new_phone>", "Change a phone number"),
+    ("phone <name>", "Show phone numbers for a contact"),
+    ("all", "Show all contacts"),
+    ("delete <name>", "Delete a contact"),
+    ("add-email <name> <email>", "Add or update contact email"),
+    ("add-address <name> -- <address>", "Add or update contact address"),
+    ("add-note <title> -- <text> -- <tag1, tag2>", "Add a note with optional tags"),
+    ("delete-note <title>", "Delete a note by title"),
+    ("edit-note <title> -- <new text>", "Edit note text and update timestamp"),
+    ("search-notes <query>", "Search notes by title, text, or tags"),
+    ("show-email <name>", "Show email for a contact"),
+    ("show-address <name>", "Show address for a contact"),
+    ("show-notes", "Show all notes in a table"),
+    ("search <query>", "Search across all fields"),
+    ("search-name <query>", "Search by name"),
+    ("search-phone <query>", "Search by phone"),
+    ("search-email <query>", "Search by email"),
+    ("search-address <query>", "Search by address"),
+    ("search-birthday <query>", "Search by birthday"),
+    ("add-birthday <name> <DD.MM.YYYY>", "Add birthday to a contact"),
+    ("show-birthday <name>", "Show birthday for a contact"),
+    ("birthdays [days]", "Show upcoming birthdays (default: 7 days)"),
+    ("help", "Show this help message"),
+    ("close / exit", "Exit the program"),
+]
 
 WELCOME_MESSAGE = "Welcome to the assistant bot!"
 HELLO_MESSAGE = "How can I help you?"

--- a/app/message_texts.py
+++ b/app/message_texts.py
@@ -59,11 +59,11 @@ INPUT_ERROR_CONTACT_NOT_FOUND = "Contact not found."
 INPUT_ERROR_ENTER_NAME = "Enter user name."
 
 UNKNOWN_COMMAND = (
-    "Unknown command. Try: hello, add, change, phone, all, delete, "
+    "Unknown command. Try: help to see all commands. Or one of this: hello, add, change, phone, all, delete, "
     "add-email, add-address, add-note, show-email, show-address, show-notes, search, "
     "search-name, search-phone, search-email, search-address, search-birthday, "
     "add-birthday, show-birthday, birthdays, "
-    "delete-note, edit-note, search-notes, help, close, exit"
+    "delete-note, edit-note, search-notes, close, exit"
 )
 
 HELP_COMMANDS: list[tuple[str, str]] = [
@@ -91,7 +91,7 @@ HELP_COMMANDS: list[tuple[str, str]] = [
     ("add-birthday <name> <DD.MM.YYYY>", "Add birthday to a contact"),
     ("show-birthday <name>", "Show birthday for a contact"),
     ("birthdays [days]", "Show upcoming birthdays (default: 7 days)"),
-    ("help", "Show this help message"),
+	("help", "Show this help message"),
     ("close / exit", "Exit the program"),
 ]
 

--- a/app/messages.py
+++ b/app/messages.py
@@ -77,10 +77,12 @@ def help_message() -> str:
     """Return help as a two-column aligned table matching the contacts style."""
     title = "=== Available Commands ==="
     col1_width = max(len(cmd) for cmd, _ in HELP_COMMANDS)
+    col2_width = max(len(desc) for _, desc in HELP_COMMANDS)
     header = f"{'Command':<{col1_width}} | Description"
+    divider = "-" * (col1_width + 1) + "+" + "-" * (col2_width + 1)
     rows = [f"{cmd:<{col1_width}} | {desc}" for cmd, desc in HELP_COMMANDS]
     separator = " " * len(title)
-    return f"{title}\n{separator}\n{header}\n" + "\n".join(rows)
+    return f"{title}\n{separator}\n{header}\n{divider}\n" + "\n".join(rows)
 
 
 @output_formatter(color=Fore.CYAN)

--- a/app/messages.py
+++ b/app/messages.py
@@ -56,6 +56,7 @@ from app.message_texts import (
     NOTE_UPDATED,
     NOTE_NOT_FOUND,
     NO_MATCHING_NOTES,
+    HELP_COMMANDS,
 )
 
 
@@ -69,6 +70,17 @@ def welcome_message() -> str:
 def hello_message() -> str:
     """Return greeting message."""
     return HELLO_MESSAGE
+
+
+@output_formatter(color=Fore.CYAN)
+def help_message() -> str:
+    """Return help as a two-column aligned table matching the contacts style."""
+    title = "=== Available Commands ==="
+    col1_width = max(len(cmd) for cmd, _ in HELP_COMMANDS)
+    header = f"{'Command':<{col1_width}} | Description"
+    rows = [f"{cmd:<{col1_width}} | {desc}" for cmd, desc in HELP_COMMANDS]
+    separator = " " * len(title)
+    return f"{title}\n{separator}\n{header}\n" + "\n".join(rows)
 
 
 @output_formatter(color=Fore.CYAN)


### PR DESCRIPTION
Summary
Added help command that displays all available commands with their expected input and descriptions
Output is formatted as a two-column aligned table (Command | Description) matching the existing contacts display style
Updated HELP_COMMANDS list to include all note-related commands (add-note, delete-note, edit-note, search-notes) with correct usage syntax
